### PR TITLE
Remove NaNs after merging indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ financial-rl-trading/
 ```python
 from src.data.data_processor import process_data
 
-# Download and process stock data
+# Download and process stock data (drops missing values and resets index)
 data = process_data('SPY', start_date='2020-01-01')
 ```
 

--- a/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
+++ b/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
@@ -1112,9 +1112,10 @@ def process_data(symbol, start_date=None, end_date=None):
     # Calculate technical indicators
     indicators = calculate_technical_indicators(data)
     
-    # Merge data
-    processed_data = pd.concat([data, indicators], axis=1)
-    
+    # Merge data and remove rows with missing values
+    processed_data = pd.concat([data, indicators], axis=1).dropna()
+    processed_data.reset_index(inplace=True)
+
     return processed_data
 ```
 
@@ -1138,7 +1139,7 @@ def process_multi_assets(symbols, start_date=None, end_date=None, include_correl
     
     # Process each asset
     for symbol in symbols:
-        asset_data[symbol] = process_data(symbol, start_date, end_date)
+        asset_data[symbol] = process_data(symbol, start_date, end_date)  # drops NaNs and resets index
     
     # Align date indices
     common_dates = set.intersection(*[set(data.index) for data in asset_data.values()])

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -44,7 +44,7 @@ from src.data.data_processor import download_stock_data, process_data
 # Download single asset data
 data = download_stock_data(symbol="SPY", start_date="2020-01-01", end_date="2022-12-31")
 
-# Process data and calculate technical indicators
+# Process data and calculate technical indicators (drops missing values and resets index)
 processed_data = process_data(symbol="SPY", start_date="2020-01-01", end_date="2022-12-31")
 ```
 
@@ -57,7 +57,7 @@ processed_data = process_data(symbol="SPY", start_date="2020-01-01", end_date="2
 #### Return Values
 
 - `download_stock_data`: pandas DataFrame with OHLCV data
-- `process_data`: processed pandas DataFrame with added technical indicators
+- `process_data`: processed pandas DataFrame with added technical indicators; rows with missing values removed and index reset
 
 ### 3.2 Multi-Asset Data Processing
 
@@ -342,7 +342,7 @@ from src.data.data_processor import process_data
 from src.models.trading_env import TradingEnv
 from src.models.grpo_agent import GRPOAgent
 
-# Process data
+# Process data (missing values removed and index reset)
 data = process_data('SPY', start_date='2020-01-01', end_date='2022-01-01')
 
 # Split train/test data

--- a/examples/optimize_and_benchmark.py
+++ b/examples/optimize_and_benchmark.py
@@ -40,7 +40,7 @@ def main(args):
     # 주식 데이터 다운로드 및 처리
     print(f"\n데이터 다운로드 및 처리 중... 심볼: {args.symbol}")
     data = process_data(args.symbol, start_date=args.start_date, end_date=args.end_date)
-    print(f"처리된 데이터 크기: {len(data)} 행")
+    print(f"처리된 데이터 크기: {len(data)} 행 (결측치 제거 후)")
     
     # 데이터 저장 (선택적)
     if args.save_data:

--- a/examples/trading_example.py
+++ b/examples/trading_example.py
@@ -8,8 +8,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 def main():
-    # Download and process data
+    # Download and process data (missing values are dropped and index reset)
     data = process_data('SPY', start_date='2020-01-01')
+    print(data.head())
     
     # Create environment
     env = TradingEnv(

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -38,7 +38,10 @@ def process_data(symbol, start_date=None, end_date=None):
     # Calculate technical indicators
     indicators = calculate_technical_indicators(data)
     
-    # Merge data with indicators
-    processed_data = pd.concat([data, indicators], axis=1)
-    
+    # Merge data with indicators and remove rows with missing values
+    processed_data = pd.concat([data, indicators], axis=1).dropna()
+
+    # Reset index to maintain sequential ordering after dropping NaNs
+    processed_data.reset_index(inplace=True)
+
     return processed_data


### PR DESCRIPTION
## Summary
- drop missing values after merging raw prices with indicators
- reset index post-dropna to ensure continuous rows
- document and example updates reflecting cleaned data

## Testing
- `python src/tests/run_tests.py --type all` *(fails: cannot import JSONLogger; missing EnhancedDataProcessor; NaN action probabilities)*

------
https://chatgpt.com/codex/tasks/task_e_68bc554c14248324ad6b6b7a0604f8c1