### PR TITLE
Add training-period normalization and data splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ financial-rl-trading/
 from src.data.data_processor import process_data
 
 # Download and process stock data
-data = process_data('SPY', start_date='2020-01-01')
+data_splits = process_data('SPY', start_date='2020-01-01')
+data = data_splits['train']
 ```
 
 ### Setting Up Trading Environment

--- a/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
+++ b/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
@@ -1094,28 +1094,19 @@ The data processing pipeline is responsible for collecting, preprocessing, and c
 ### 7.2 Single Asset Data Processing
 
 ```python
-def process_data(symbol, start_date=None, end_date=None):
+def process_data(symbol, start_date=None, end_date=None,
+                 train_ratio=0.7, val_ratio=0.15):
     """
-    Download and process single asset data
-    
-    Args:
-        symbol (str): Asset symbol
-        start_date (str, optional): Start date (YYYY-MM-DD format)
-        end_date (str, optional): End date (YYYY-MM-DD format)
-        
-    Returns:
-        pd.DataFrame: Processed data
+    Download and process single asset data and return train/validation/test
+    splits normalised using training statistics.
     """
-    # Download data
-    data = download_stock_data(symbol, start_date, end_date)
-    
-    # Calculate technical indicators
-    indicators = calculate_technical_indicators(data)
-    
-    # Merge data
-    processed_data = pd.concat([data, indicators], axis=1)
-    
-    return processed_data
+    # ... implementation ...
+    return {
+        'train': train_df,
+        'val': val_df,
+        'test': test_df,
+        'stats': stats,
+    }
 ```
 
 ### 7.3 Multi-Asset Data Processing
@@ -1135,10 +1126,11 @@ def process_multi_assets(symbols, start_date=None, end_date=None, include_correl
         dict: Processed multi-asset data
     """
     asset_data = {}
-    
+
     # Process each asset
     for symbol in symbols:
-        asset_data[symbol] = process_data(symbol, start_date, end_date)
+        splits = process_data(symbol, start_date, end_date)
+        asset_data[symbol] = splits['train']
     
     # Align date indices
     common_dates = set.intersection(*[set(data.index) for data in asset_data.values()])

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -45,7 +45,10 @@ from src.data.data_processor import download_stock_data, process_data
 data = download_stock_data(symbol="SPY", start_date="2020-01-01", end_date="2022-12-31")
 
 # Process data and calculate technical indicators
-processed_data = process_data(symbol="SPY", start_date="2020-01-01", end_date="2022-12-31")
+splits = process_data(symbol="SPY", start_date="2020-01-01", end_date="2022-12-31")
+train_data = splits['train']
+val_data = splits['val']
+test_data = splits['test']
 ```
 
 #### Key Parameters
@@ -57,7 +60,8 @@ processed_data = process_data(symbol="SPY", start_date="2020-01-01", end_date="2
 #### Return Values
 
 - `download_stock_data`: pandas DataFrame with OHLCV data
-- `process_data`: processed pandas DataFrame with added technical indicators
+- `process_data`: dict containing processed ``train``, ``val``, ``test`` DataFrames
+  and training-period normalization statistics
 
 ### 3.2 Multi-Asset Data Processing
 
@@ -343,11 +347,9 @@ from src.models.trading_env import TradingEnv
 from src.models.grpo_agent import GRPOAgent
 
 # Process data
-data = process_data('SPY', start_date='2020-01-01', end_date='2022-01-01')
-
-# Split train/test data
-train_data = data.iloc[:int(len(data)*0.8)]
-test_data = data.iloc[int(len(data)*0.8):]
+splits = process_data('SPY', start_date='2020-01-01', end_date='2022-01-01')
+train_data = splits['train']
+test_data = splits['test']
 
 # Create environment
 env = TradingEnv(

--- a/examples/backtest_deepseek_grpo.py
+++ b/examples/backtest_deepseek_grpo.py
@@ -752,7 +752,8 @@ def save_backtest_results(results, metrics, comparison=None, regime_stats=None, 
 def load_benchmark_data(symbol, start_date, end_date):
     """벤치마크 데이터 로드"""
     try:
-        benchmark_data = process_data(symbol, start_date, end_date)
+        splits = process_data(symbol, start_date, end_date)
+        benchmark_data = pd.concat([splits['train'], splits['val'], splits['test']])
         return benchmark_data
     except Exception as e:
         logger.error(f"벤치마크 데이터 로드 오류: {e}")
@@ -883,7 +884,8 @@ def main():
     all_data = []
     for symbol in args.symbols:
         try:
-            data = process_data(symbol, start_date=args.start_date, end_date=args.end_date)
+            splits = process_data(symbol, start_date=args.start_date, end_date=args.end_date)
+            data = pd.concat([splits['train'], splits['val'], splits['test']])
             all_data.append(data)
         except Exception as e:
             logger.error(f"{symbol} 데이터 로드 오류: {e}")

--- a/examples/integration_example.py
+++ b/examples/integration_example.py
@@ -72,7 +72,8 @@ def main():
     asset_data = {}
     for symbol in config['symbols']:
         print(f"  - {symbol} 처리 중...")
-        data = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
+        splits = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
+        data = pd.concat([splits['train'], splits['val'], splits['test']])
         asset_data[symbol] = data
     
     # 학습/테스트 분할

--- a/examples/multi_asset_example.py
+++ b/examples/multi_asset_example.py
@@ -65,7 +65,8 @@ def main():
     asset_data = {}
     for symbol in config['symbols']:
         print(f"  {symbol} 처리 중...")
-        data = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
+        splits = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
+        data = pd.concat([splits['train'], splits['val'], splits['test']])
         asset_data[symbol] = data
     
     # 학습/테스트 분할

--- a/examples/optimize_and_benchmark.py
+++ b/examples/optimize_and_benchmark.py
@@ -39,7 +39,8 @@ def main(args):
     
     # 주식 데이터 다운로드 및 처리
     print(f"\n데이터 다운로드 및 처리 중... 심볼: {args.symbol}")
-    data = process_data(args.symbol, start_date=args.start_date, end_date=args.end_date)
+    data_splits = process_data(args.symbol, start_date=args.start_date, end_date=args.end_date)
+    data = pd.concat([data_splits['train'], data_splits['val'], data_splits['test']])
     print(f"처리된 데이터 크기: {len(data)} 행")
     
     # 데이터 저장 (선택적)

--- a/examples/trading_example.py
+++ b/examples/trading_example.py
@@ -9,7 +9,8 @@ import numpy as np
 
 def main():
     # Download and process data
-    data = process_data('SPY', start_date='2020-01-01')
+    data_splits = process_data('SPY', start_date='2020-01-01')
+    data = data_splits['train']
     
     # Create environment
     env = TradingEnv(

--- a/examples/train_grpo.py
+++ b/examples/train_grpo.py
@@ -114,7 +114,8 @@ def main():
     np.random.seed(42)
     
     # Download and process data
-    data = process_data('SPY', start_date='2020-01-01')
+    data_splits = process_data('SPY', start_date='2020-01-01')
+    data = data_splits['train']
     
     # Create environment
     env = TradingEnv(

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -20,25 +20,52 @@ def download_stock_data(symbol, start_date=None, end_date=None):
     print(f"다운로드 완료: {len(data)} 데이터 포인트\n")
     return data
 
-def process_data(symbol, start_date=None, end_date=None):
+def process_data(symbol, start_date=None, end_date=None,
+                 train_ratio=0.7, val_ratio=0.15):
     """
-    Download and process stock data
-    
+    Download stock data, calculate technical indicators, and split into
+    train/validation/test sets. Normalization statistics are computed from
+    the training period and reused for validation and test periods.
+
     Args:
         symbol (str): Stock symbol
         start_date (str, optional): Start date in YYYY-MM-DD format
         end_date (str, optional): End date in YYYY-MM-DD format
-        
+        train_ratio (float, optional): Proportion of data used for training.
+            Defaults to 0.7.
+        val_ratio (float, optional): Proportion of data used for validation.
+            Defaults to 0.15. The remainder is used for testing.
+
     Returns:
-        pd.DataFrame: Processed DataFrame with technical indicators
+        dict: Dictionary with keys ``'train'``, ``'val'``, ``'test'`` containing
+        processed ``pd.DataFrame`` objects. The dictionary also includes a
+        ``'stats'`` key with the normalization statistics from the training
+        set.
     """
     # Download data
     data = download_stock_data(symbol, start_date, end_date)
-    
-    # Calculate technical indicators
-    indicators = calculate_technical_indicators(data)
-    
-    # Merge data with indicators
-    processed_data = pd.concat([data, indicators], axis=1)
-    
-    return processed_data
+
+    n = len(data)
+    train_end = int(n * train_ratio)
+    val_end = train_end + int(n * val_ratio)
+
+    train_data = data.iloc[:train_end]
+    val_data = data.iloc[train_end:val_end]
+    test_data = data.iloc[val_end:]
+
+    # Calculate technical indicators using training statistics
+    train_indicators, stats = calculate_technical_indicators(
+        train_data, return_stats=True)
+    val_indicators = calculate_technical_indicators(val_data, stats)
+    test_indicators = calculate_technical_indicators(test_data, stats)
+
+    train_processed = pd.concat([train_data, train_indicators], axis=1)
+    val_processed = pd.concat([val_data, val_indicators], axis=1)
+    test_processed = pd.concat([test_data, test_indicators], axis=1)
+
+    return {
+        'train': train_processed,
+        'val': val_processed,
+        'test': test_processed,
+        'stats': stats,
+    }

--- a/src/models/multi_asset_env.py
+++ b/src/models/multi_asset_env.py
@@ -441,8 +441,8 @@ if __name__ == "__main__":
     asset_data = {}
     
     for symbol in symbols:
-        data = dp.process_data(symbol, start_date='2020-01-01', end_date='2021-01-01')
-        asset_data[symbol] = data
+        data_splits = dp.process_data(symbol, start_date='2020-01-01', end_date='2021-01-01')
+        asset_data[symbol] = data_splits['train']
     
     # 다중 자산 트레이딩 환경 생성
     env = MultiAssetTradingEnv(

--- a/src/utils/indicators.py
+++ b/src/utils/indicators.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 
-def calculate_technical_indicators(data):
+def calculate_technical_indicators(data, stats=None, return_stats=False):
     """
     Calculate various technical indicators for the given price data
     
@@ -10,6 +10,11 @@ def calculate_technical_indicators(data):
         
     Returns:
         pd.DataFrame: DataFrame with technical indicators
+        dict (optional): Dictionary of normalization statistics when
+            ``return_stats`` is True. The dictionary maps column names to
+            ``{"mean": value, "std": value}`` pairs and can be reused to
+            normalize other datasets (e.g., validation and test sets) using
+            the same training-period statistics.
     """
     df = pd.DataFrame(index=data.index)
     
@@ -73,9 +78,17 @@ def calculate_technical_indicators(data):
     # Normalize indicators (Z-score)
     normalize_cols = ['RSI', 'ForceIndex2', '%K', '%D', 'MACD', 'MACDSignal',
                      'BBWidth', 'ATR', 'VPT', 'VPT_MA', 'OBV', 'ROC']
+    stats = {} if stats is None else stats
     for col in normalize_cols:
-        mean = df[col].mean()
-        std = df[col].std()
+        if col in stats:
+            mean = stats[col]['mean']
+            std = stats[col]['std']
+        else:
+            mean = df[col].mean()
+            std = df[col].std()
+            stats[col] = {'mean': mean, 'std': std}
         df[f'{col}_norm'] = (df[col] - mean) / (std + 1e-9)
-    
+
+    if return_stats:
+        return df, stats
     return df


### PR DESCRIPTION
## Summary
- add optional stats return to `calculate_technical_indicators` for training-period normalization
- expand `process_data` to output train/val/test splits using training stats
- update examples and documentation to reflect new API

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'JSONLogger'; ModuleNotFoundError: No module named 'src.data.enhanced_processor'; ImportError: cannot import name 'FeatureAttention')*


------
https://chatgpt.com/codex/tasks/task_e_68bc55d9538083248fb5cfbf1fe01df4