### PR TITLE
Fix portfolio valuation timing and add TradingEnv tests

### DIFF
--- a/src/models/trading_env.py
+++ b/src/models/trading_env.py
@@ -98,6 +98,7 @@ class TradingEnv(gym.Env):
         """Execute one step in the environment"""
         # Get current price and portfolio value
         current_price = float(self.data.loc[self.index, 'Close'])
+        next_price = float(self.data.loc[self.index + 1, 'Close']) if self.index < self.n_steps - 1 else current_price
         old_portfolio_value = self.cash + (self.holdings * current_price)
         
         # Check stop loss
@@ -166,16 +167,19 @@ class TradingEnv(gym.Env):
         self.index += 1
         if self.position != 0:
             self.position_duration += 1
-        
+
+        # Determine price for portfolio valuation
+        valuation_price = next_price if self.index < self.n_steps else exec_price
+
         # Calculate new portfolio value and return
-        new_portfolio_value = self.cash + (self.holdings * current_price)
+        new_portfolio_value = self.cash + (self.holdings * valuation_price)
         self.portfolio_values.append(new_portfolio_value)
         daily_return = (new_portfolio_value / old_portfolio_value) - 1
         self.daily_returns.append(daily_return)
-        
+
         # Calculate reward
         reward = self._calculate_reward(old_portfolio_value, new_portfolio_value, action)
-        
+
         # Check if episode is done
         done = self.index >= self.n_steps - 1
         

--- a/tests/test_trading_env.py
+++ b/tests/test_trading_env.py
@@ -1,0 +1,55 @@
+import unittest
+import pandas as pd
+
+from src.models.trading_env import TradingEnv
+
+
+class TestTradingEnv(unittest.TestCase):
+    """Tests for the basic TradingEnv."""
+
+    def _create_env(self, prices):
+        data = pd.DataFrame({"Close": prices})
+        # Add required indicator columns with neutral values
+        cols = [
+            "RSI_norm",
+            "ForceIndex2_norm",
+            "%K_norm",
+            "%D_norm",
+            "MACD_norm",
+            "MACDSignal_norm",
+            "BBWidth_norm",
+            "ATR_norm",
+            "VPT_norm",
+            "VPT_MA_norm",
+            "OBV_norm",
+            "ROC_norm",
+        ]
+        for col in cols:
+            data[col] = 0.0
+
+        env = TradingEnv(
+            data=data,
+            initial_capital=1000,
+            trading_cost=0.0,
+            slippage=0.0,
+            risk_free_rate=0.0,
+            max_position_size=1.0,
+            stop_loss_pct=0.02,
+        )
+        env.reset()
+        return env
+
+    def test_buy_profit(self):
+        env = self._create_env([100, 110])
+        _, reward, done, _ = env.step(1)
+        self.assertAlmostEqual(env.portfolio_values[-1], 1010.0)
+        self.assertTrue(reward > 0)
+        self.assertTrue(done)
+
+    def test_buy_loss(self):
+        env = self._create_env([100, 90])
+        _, reward, done, _ = env.step(1)
+        self.assertAlmostEqual(env.portfolio_values[-1], 990.0)
+        self.assertTrue(reward < 0)
+        self.assertTrue(done)
+


### PR DESCRIPTION
## Summary
- Separate current and next prices in `TradingEnv.step`
- Value portfolio using next price after trades with exec price fallback
- Add unit tests covering profitable and losing buy scenarios

## Testing
- `pytest tests/test_trading_env.py -q` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas -q` *(fails: Could not find a version that satisfies the requirement pandas (403 Forbidden))*

------
https://chatgpt.com/codex/tasks/task_e_68bc55b9bf448324b2c09acce2cd952d