### PR TITLE
Fix datetime index reset bug

### DIFF
--- a/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
+++ b/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
@@ -1114,7 +1114,7 @@ def process_data(symbol, start_date=None, end_date=None):
     
     # Merge data and remove rows with missing values
     processed_data = pd.concat([data, indicators], axis=1).dropna()
-    processed_data.reset_index(inplace=True)
+    # Keep DatetimeIndex to preserve date alignment across assets
 
     return processed_data
 ```
@@ -1139,7 +1139,7 @@ def process_multi_assets(symbols, start_date=None, end_date=None, include_correl
     
     # Process each asset
     for symbol in symbols:
-        asset_data[symbol] = process_data(symbol, start_date, end_date)  # drops NaNs and resets index
+        asset_data[symbol] = process_data(symbol, start_date, end_date)  # drops NaNs, preserves DatetimeIndex
     
     # Align date indices
     common_dates = set.intersection(*[set(data.index) for data in asset_data.values()])

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -39,9 +39,7 @@ def process_data(symbol, start_date=None, end_date=None):
     indicators = calculate_technical_indicators(data)
     
     # Merge data with indicators and remove rows with missing values
+    # Keep DatetimeIndex to preserve date alignment across assets
     processed_data = pd.concat([data, indicators], axis=1).dropna()
-
-    # Reset index to maintain sequential ordering after dropping NaNs
-    processed_data.reset_index(inplace=True)
 
     return processed_data


### PR DESCRIPTION
Remove `reset_index` call in `process_data` to preserve `DatetimeIndex` for correct multi-asset date alignment.

---
<a href="https://cursor.com/background-agent?bcId=bc-d921083b-fd26-4b9d-8d7c-f9a3b465ac6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d921083b-fd26-4b9d-8d7c-f9a3b465ac6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

