### PR TITLE
Fix data processing NaN and index issues

### DIFF
--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -52,7 +52,11 @@ def process_data(symbol, start_date=None, end_date=None,
             Defaults to 0.15. The remainder is used for testing.
 
     Returns:
-        pd.DataFrame: Processed DataFrame with technical indicators
+        dict: Dictionary with keys 'train', 'val', 'test', and 'stats'.
+            'train', 'val', and 'test' are NaN-free DataFrames with
+            integer indices (after final dropna and reset_index), and
+            'stats' contains normalization statistics used for indicator
+            normalization across splits.
 
     Raises:
         ValueError: Propagated from download_stock_data when data download fails.


### PR DESCRIPTION
Update `process_data` docstring to accurately reflect its return of NaN-free DataFrames with integer indices.

The initial bug report indicated missing `dropna()` and `reset_index()` operations. However, these were found to be correctly applied within the function. This PR clarifies the docstring to accurately describe the existing, correct behavior, ensuring the API contract is properly documented.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b3989e3-ef6c-41c0-8f20-4614c11a3b1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1b3989e3-ef6c-41c0-8f20-4614c11a3b1d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

