### PR TITLE
Add missing API dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,7 @@ scipy>=1.8.0
 pytest>=7.0.0
 bayesian-optimization>=1.4.0
 tqdm>=4.64.0
+fastapi>=0.100.0
+uvicorn>=0.20.0
+websockets>=10.4
+pydantic>=1.10.0


### PR DESCRIPTION
## Summary
- Include FastAPI, Uvicorn, WebSockets, and Pydantic in requirements
- Ensure tqdm dependency has a newline terminator

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.100.0)*
- `python - <<'PY'
import fastapi, uvicorn, websockets, pydantic, numpy, pandas
print('imports ok')
PY` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'src.data.enhanced_processor')*

------
https://chatgpt.com/codex/tasks/task_e_68bc64fef31c8324adba5960279e8294