### PR TITLE
Clarify process_data return type and update examples

### DIFF
--- a/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
+++ b/docs/DeepSeek-R1_Financial_Trading_Model_Architecture.md
@@ -1097,15 +1097,16 @@ The data processing pipeline is responsible for collecting, preprocessing, and c
 def process_data(symbol, start_date=None, end_date=None,
                  train_ratio=0.7, val_ratio=0.15):
     """
-    Download and process single asset data and return train/validation/test
-    splits normalised using training statistics.
+    Download stock data, compute technical indicators, and return a processed
+    DataFrame. The `train_ratio` and `val_ratio` parameters are deprecated and
+    ignored, retained only for backward compatibility.
     """
     # Download data
     data = download_stock_data(symbol, start_date, end_date)
-    
+
     # Calculate technical indicators
     indicators = calculate_technical_indicators(data)
-    
+
     # Merge data and remove rows with missing values
     processed_data = pd.concat([data, indicators], axis=1).dropna()
     # Keep DatetimeIndex to preserve date alignment across assets

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -344,10 +344,11 @@ from src.data.data_processor import process_data
 from src.models.trading_env import TradingEnv
 from src.models.grpo_agent import GRPOAgent
 
-# Process data
-splits = process_data('SPY', start_date='2020-01-01', end_date='2022-01-01')
-train_data = splits['train']
-test_data = splits['test']
+# Process data and create train/test split
+data = process_data('SPY', start_date='2020-01-01', end_date='2022-01-01')
+split_idx = int(len(data) * 0.8)
+train_data = data.iloc[:split_idx]
+test_data = data.iloc[split_idx:]
 
 # Create environment
 env = TradingEnv(

--- a/examples/backtest_deepseek_grpo.py
+++ b/examples/backtest_deepseek_grpo.py
@@ -752,8 +752,7 @@ def save_backtest_results(results, metrics, comparison=None, regime_stats=None, 
 def load_benchmark_data(symbol, start_date, end_date):
     """벤치마크 데이터 로드"""
     try:
-        splits = process_data(symbol, start_date, end_date)
-        benchmark_data = pd.concat([splits['train'], splits['val'], splits['test']])
+        benchmark_data = process_data(symbol, start_date, end_date)
         return benchmark_data
     except Exception as e:
         logger.error(f"벤치마크 데이터 로드 오류: {e}")
@@ -884,8 +883,7 @@ def main():
     all_data = []
     for symbol in args.symbols:
         try:
-            splits = process_data(symbol, start_date=args.start_date, end_date=args.end_date)
-            data = pd.concat([splits['train'], splits['val'], splits['test']])
+            data = process_data(symbol, start_date=args.start_date, end_date=args.end_date)
             all_data.append(data)
         except Exception as e:
             logger.error(f"{symbol} 데이터 로드 오류: {e}")

--- a/examples/integration_example.py
+++ b/examples/integration_example.py
@@ -72,8 +72,7 @@ def main():
     asset_data = {}
     for symbol in config['symbols']:
         print(f"  - {symbol} 처리 중...")
-        splits = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
-        data = pd.concat([splits['train'], splits['val'], splits['test']])
+        data = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
         asset_data[symbol] = data
     
     # 학습/테스트 분할

--- a/examples/multi_asset_example.py
+++ b/examples/multi_asset_example.py
@@ -65,8 +65,7 @@ def main():
     asset_data = {}
     for symbol in config['symbols']:
         print(f"  {symbol} 처리 중...")
-        splits = process_data(symbol, start_date=config['start_date'], end_date=config['end_date'])
-        data = pd.concat([splits['train'], splits['val'], splits['test']]).reset_index(drop=True)
+        data = process_data(symbol, start_date=config['start_date'], end_date=config['end_date']).reset_index(drop=True)
         asset_data[symbol] = data
     
     # 학습/테스트 분할

--- a/examples/optimize_and_benchmark.py
+++ b/examples/optimize_and_benchmark.py
@@ -39,8 +39,7 @@ def main(args):
     
     # 주식 데이터 다운로드 및 처리
     print(f"\n데이터 다운로드 및 처리 중... 심볼: {args.symbol}")
-    data_splits = process_data(args.symbol, start_date=args.start_date, end_date=args.end_date)
-    data = pd.concat([data_splits['train'], data_splits['val'], data_splits['test']])
+    data = process_data(args.symbol, start_date=args.start_date, end_date=args.end_date)
     print(f"처리된 데이터 크기: {len(data)} 행")
 
     

--- a/examples/trading_example.py
+++ b/examples/trading_example.py
@@ -9,8 +9,7 @@ import numpy as np
 
 def main():
     # Download and process data
-    data_splits = process_data('SPY', start_date='2020-01-01')
-    data = data_splits['train']
+    data = process_data('SPY', start_date='2020-01-01')
     
     # Create environment
     env = TradingEnv(

--- a/examples/train_grpo.py
+++ b/examples/train_grpo.py
@@ -114,8 +114,7 @@ def main():
     np.random.seed(42)
     
     # Download and process data
-    data_splits = process_data('SPY', start_date='2020-01-01')
-    data = data_splits['train']
+    data = process_data('SPY', start_date='2020-01-01')
     
     # Create environment
     env = TradingEnv(

--- a/src/data/data_processor.py
+++ b/src/data/data_processor.py
@@ -38,13 +38,14 @@ def download_stock_data(symbol, start_date=None, end_date=None):
 def process_data(symbol, start_date=None, end_date=None,
                  train_ratio=0.7, val_ratio=0.15):
     """
-    Download stock data and compute technical indicators.
+    Download stock data, compute technical indicators, and return a processed
+    DataFrame.
 
     Note:
         This function no longer splits the dataset into train/validation/test
         sets. It returns a single processed DataFrame. The parameters
-        `train_ratio` and `val_ratio` are deprecated and ignored, retained
-        only for backward compatibility.
+        `train_ratio` and `val_ratio` are retained only for backward
+        compatibility and are ignored.
 
     Args:
         symbol (str): Stock symbol
@@ -54,11 +55,8 @@ def process_data(symbol, start_date=None, end_date=None,
         val_ratio (float, optional): Deprecated. Ignored.
 
     Returns:
-        dict: Dictionary with keys 'train', 'val', 'test', and 'stats'.
-            'train', 'val', and 'test' are NaN-free DataFrames with
-            integer indices (after final dropna and reset_index), and
-            'stats' contains normalization statistics used for indicator
-            normalization across splits.
+        pd.DataFrame: DataFrame containing price data and calculated
+            technical indicators with rows containing missing values removed.
 
     Raises:
         ValueError: Propagated from download_stock_data when data download fails.

--- a/src/models/multi_asset_env.py
+++ b/src/models/multi_asset_env.py
@@ -441,8 +441,7 @@ if __name__ == "__main__":
     asset_data = {}
     
     for symbol in symbols:
-        data_splits = dp.process_data(symbol, start_date='2020-01-01', end_date='2021-01-01')
-        asset_data[symbol] = data_splits['train']
+        asset_data[symbol] = dp.process_data(symbol, start_date='2020-01-01', end_date='2021-01-01')
     
     # 다중 자산 트레이딩 환경 생성
     env = MultiAssetTradingEnv(


### PR DESCRIPTION
## Summary
- revise `process_data` docstring to describe single DataFrame output and note deprecated ratios are ignored
- update examples, docs, and environment snippets to use the new `process_data` return type

## Testing
- `pytest tests/test_data_processor.py -q`
- `pytest tests/test_enhanced_processor.py -q` *(fails: ModuleNotFoundError: No module named 'src.data.enhanced_processor')*

------
https://chatgpt.com/codex/tasks/task_e_68bc66b2d00883249bc90f68a05b56a8