### PR TITLE
Fix API select_action usage and add prediction test

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,6 +2,7 @@ import os
 import logging
 import uvicorn
 import numpy as np
+import torch
 from typing import Dict, Any, List, Optional, Union
 from pathlib import Path
 from fastapi import FastAPI, Request, Depends, HTTPException, status
@@ -268,7 +269,7 @@ def create_app(model_path: str, optimization_level: str = "medium") -> FastAPI:
             state[-1] = portfolio_return
             
             # 모델 추론
-            action = model_instance.select_action(state, deterministic=True)
+            action = model_instance.select_action(state)
             
             # 행동 확률 계산 (추가 정보용)
             with torch.no_grad():
@@ -327,7 +328,7 @@ def create_app(model_path: str, optimization_level: str = "medium") -> FastAPI:
                 state[-2] = current_position
                 state[-1] = portfolio_return
                 
-                action = model_instance.select_action(state, deterministic=True)
+                action = model_instance.select_action(state)
                 
                 with torch.no_grad():
                     state_tensor = torch.FloatTensor(state).unsqueeze(0).to(model_instance.device)
@@ -364,12 +365,10 @@ def create_app(model_path: str, optimization_level: str = "medium") -> FastAPI:
     
     return app
 
-def run_app(model_path: str, host: str = "0.0.0.0", port: int = 8000, 
+def run_app(model_path: str, host: str = "0.0.0.0", port: int = 8000,
            optimization_level: str = "medium", reload: bool = False):
     """API 서버 실행"""
-    import torch
-    global import torch
-    
+
     app = create_app(model_path, optimization_level)
     
     logger.info(f"API 서버 시작 (host={host}, port={port})")

--- a/tests/test_api_prediction.py
+++ b/tests/test_api_prediction.py
@@ -1,0 +1,39 @@
+from fastapi.testclient import TestClient
+
+from src.api.app import create_app
+from src.models.grpo_agent import GRPOAgent
+
+class DummyPackager:
+    def load_model(self, model_name, version):
+        state_dim = 14
+        action_dim = 3
+        model = GRPOAgent(state_dim, action_dim, device='cpu')
+        env_config = {}
+        metadata = {"model_name": model_name, "version": version}
+        return model, env_config, metadata
+
+class DummyOptimizer:
+    def optimize_for_inference(self, model, optimization_level):
+        return model
+
+
+def test_predict_endpoint(monkeypatch):
+    monkeypatch.setattr('src.api.app.ModelPackager', lambda: DummyPackager())
+    monkeypatch.setattr('src.api.app.ModelOptimizer', lambda: DummyOptimizer())
+    app = create_app('dummy/path')
+    with TestClient(app) as client:
+        features = [
+            'RSI_norm', 'ForceIndex2_norm', '%K_norm', '%D_norm',
+            'MACD_norm', 'MACDSignal_norm', 'BBWidth_norm', 'ATR_norm',
+            'VPT_norm', 'VPT_MA_norm', 'OBV_norm', 'ROC_norm'
+        ]
+        market_data = {f: [0.0] for f in features}
+        payload = {
+            "market_data": market_data,
+            "portfolio_state": {"position": 0.0, "portfolio_return": 0.0}
+        }
+        headers = {"X-API-KEY": "default_development_key"}
+
+        response = client.post('/predict', json=payload, headers=headers)
+        assert response.status_code == 200
+        assert 'action' in response.json()


### PR DESCRIPTION
## Summary
- remove invalid global import and import torch normally
- call agent's `select_action` without unsupported deterministic flag
- add unit test covering API prediction

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68bc6690cdb483248ec479fe0bb525d6