### PR TITLE
Consolidate imports in advanced normalizer

### DIFF
--- a/src/data/advanced_normalizer.py
+++ b/src/data/advanced_normalizer.py
@@ -1,8 +1,11 @@
+import os
+import pickle
+from typing import Dict, List, Tuple, Optional, Union
+
 import numpy as np
 import pandas as pd
 import torch
 import torch.nn as nn
-from typing import Dict, List, Tuple, Optional, Union
 
 
 class AdaptiveFeatureNormalizer:
@@ -413,7 +416,6 @@ class AdaptiveFeatureNormalizer:
         Args:
             path: 저장 경로
         """
-        import pickle
         with open(path, 'wb') as f:
             pickle.dump({
                 'feature_groups': self.feature_groups,
@@ -436,7 +438,6 @@ class AdaptiveFeatureNormalizer:
         Returns:
             normalizer: 로드된 정규화기
         """
-        import pickle
         with open(path, 'rb') as f:
             data = pickle.load(f)
         
@@ -628,12 +629,9 @@ class MultiResolutionNormalizer:
         Args:
             path: 저장 경로
         """
-        import pickle
-        import os
-        
         # 디렉토리 생성
         os.makedirs(path, exist_ok=True)
-        
+
         # 메타 정보 저장
         meta_path = os.path.join(path, 'meta.pkl')
         with open(meta_path, 'wb') as f:
@@ -659,9 +657,6 @@ class MultiResolutionNormalizer:
         Returns:
             normalizer: 로드된 정규화기
         """
-        import pickle
-        import os
-        
         # 메타 정보 로드
         meta_path = os.path.join(path, 'meta.pkl')
         with open(meta_path, 'rb') as f:


### PR DESCRIPTION
## Summary
- Add missing `os` and `pickle` imports along with `pandas` and `torch`
- Remove redundant inline imports in advanced normalizer implementation

## Testing
- `python -m py_compile src/data/advanced_normalizer.py`
- `python src/tests/run_tests.py --type unit` *(fails: test_step_hold, test_stop_loss)*

------
https://chatgpt.com/codex/tasks/task_e_68bc669cadec832495ffae61c977bb68